### PR TITLE
Added Pagination Margin

### DIFF
--- a/app/src/main/java/com/mindorks/demo/DemoLoadMoreActivity.java
+++ b/app/src/main/java/com/mindorks/demo/DemoLoadMoreActivity.java
@@ -34,6 +34,7 @@ public class DemoLoadMoreActivity extends AppCompatActivity {
 
         List<InfiniteFeedInfo> feedList = Utils.loadInfiniteFeeds(this.getApplicationContext());
         mLoadMoreView.setLoadMoreResolver(new LoadMoreView(mLoadMoreView, feedList));
+        mLoadMoreView.setPaginationMargin(5);
         Log.d("DEBUG", "LoadMoreView.LOAD_VIEW_SET_COUNT " + LoadMoreView.LOAD_VIEW_SET_COUNT);
         for(int i = 0; i < LoadMoreView.LOAD_VIEW_SET_COUNT; i++){
             mLoadMoreView.addView(new ItemView(this.getApplicationContext(), feedList.get(i)));

--- a/placeholderview/src/main/java/com/mindorks/placeholderview/InfinitePlaceHolderView.java
+++ b/placeholderview/src/main/java/com/mindorks/placeholderview/InfinitePlaceHolderView.java
@@ -18,6 +18,7 @@ public class InfinitePlaceHolderView extends PlaceHolderView {
     private Object mLoadMoreResolver;
     private LoadMoreCallbackBinder mLoadMoreCallbackBinder;
     private PlaceHolderView.OnScrollListener mOnScrollListener;
+    private int mPaginationMargin = 0;
 
     public InfinitePlaceHolderView(Context context) {
         super(context);
@@ -39,14 +40,15 @@ public class InfinitePlaceHolderView extends PlaceHolderView {
                     public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
                         super.onScrolled(recyclerView, dx, dy);
                         LayoutManager layoutManager = recyclerView.getLayoutManager();
-                        if(layoutManager instanceof LinearLayoutManager) {
+                        if (layoutManager instanceof LinearLayoutManager) {
                             LinearLayoutManager linearLayoutManager = (LinearLayoutManager) layoutManager;
                             int totalItemCount = linearLayoutManager.getItemCount();
-                            int lastVisibleItem = linearLayoutManager.findLastVisibleItemPosition();
+                            int firstVisibleItem = linearLayoutManager.findFirstVisibleItemPosition();
+                            int visibleItemCount = linearLayoutManager.getChildCount();
                             if (!mIsLoadingMore
                                     && !mNoMoreToLoad
                                     && totalItemCount > 0
-                                    && totalItemCount == lastVisibleItem + 1) {
+                                    && visibleItemCount + firstVisibleItem >= totalItemCount - mPaginationMargin) {
                                 mIsLoadingMore = true;
                                 new Handler(Looper.getMainLooper()).post(new Runnable() {
                                     @Override
@@ -62,19 +64,19 @@ public class InfinitePlaceHolderView extends PlaceHolderView {
         addOnScrollListener(mOnScrollListener);
     }
 
-    public <T>void setLoadMoreResolver(T loadMoreResolver) {
+    public <T> void setLoadMoreResolver(T loadMoreResolver) {
         mLoadMoreResolver = loadMoreResolver;
         mLoadMoreCallbackBinder = Binding.bindLoadMoreCallback(loadMoreResolver);
         mNoMoreToLoad = false;
         setLoadMoreListener();
     }
 
-    public void noMoreToLoad(){
+    public void noMoreToLoad() {
         mNoMoreToLoad = true;
         removeOnScrollListener(mOnScrollListener);
     }
 
-    public void loadingDone(){
+    public void loadingDone() {
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
@@ -86,5 +88,9 @@ public class InfinitePlaceHolderView extends PlaceHolderView {
 
     public int getViewCount() {
         return super.getViewResolverCount() - 1;
+    }
+
+    public void setPaginationMargin(int margin) {
+        mPaginationMargin = margin;
     }
 }


### PR DESCRIPTION
Added the pagination margin in the InfinitePlaceHolderView so that the user can decide when the loadMore method should call. Also it get rid of showing the loader to the user every time.

The default margin will be 0 means the loadMore() method will call once the user scroll till end of the list.

User can set the margin by calling
`setPaginationMargin(margin);` //margin : integer value

Suppose the margin is 5, the loadMore() will be called when there are 5 data sets to reach the end of the list, so that the data will be ready when the user reaches the end of the list.
