### PR TITLE
Make stop intercepting parent ViewGroup touch event

### DIFF
--- a/placeholderview/src/main/java/com/mindorks/placeholderview/SwipePlaceHolderView.java
+++ b/placeholderview/src/main/java/com/mindorks/placeholderview/SwipePlaceHolderView.java
@@ -784,11 +784,13 @@ public class SwipePlaceHolderView extends FrameLayout implements
                 case MotionEvent.ACTION_DOWN: {
                     mLastMotionY = (int) ev.getRawY();
                     mLastMotionX = (int) ev.getRawX();
+                    getParent().requestDisallowInterceptTouchEvent(true);
                     break;
                 }
 
                 case MotionEvent.ACTION_CANCEL:
                 case MotionEvent.ACTION_UP:
+                    getParent().requestDisallowInterceptTouchEvent(false);
                     mIsBeingDragged = false;
                     break;
             }


### PR DESCRIPTION
Related to #35.

This Pull Request make PHV can swipe in ViewPager.
Now `FrameView` prevent intercepting by parent ViewGroup touch event (ex. ViewPager or ScrollView)